### PR TITLE
Let swiper handle how many slides to display

### DIFF
--- a/src/swiper.js
+++ b/src/swiper.js
@@ -2,9 +2,6 @@ import Swiper from 'swiper'
 
 module.exports = {
   renderSwiper: function() {
-    var width = window.innerWidth;
-    var height = window.innerHeight;
-
     function ellipsizeTextBox(el) {
       var wordArray = el.innerHTML.split(' ');
       while (el.scrollHeight > el.offsetHeight) {
@@ -13,27 +10,27 @@ module.exports = {
       }
     }
 
-    var all = document.getElementsByClassName('all');
-    var cardTable = document.getElementsByClassName('card_table');
+    var container = document.getElementById('container');
+    var slides = document.getElementsByClassName('swiper-slide');
     var usages = document.getElementsByClassName('usage');
 
-    var allHeight, cardHeight, usageVisibility;
+    var height = window.innerHeight;
+    
+    var containerHeight, slideHeight, usageVisibility;
     if (height <= 420) {
-      allHeight = "300px";
-      cardHeight = "250px";
+      containerHeight = "300px";
+      slideHeight = "250px";
       usageVisibility = "hidden";
     } else {
-      allHeight = "470px";
-      cardHeight = "400px";
+      containerHeight = "470px";
+      slideHeight = "400px";
       usageVisibility = "visible";
     }
 
-    for (var i = 0; i < all.length; i++) {
-      all[i].style.height = allHeight;
-    }
+    if (container) {container.style.height = containerHeight}
 
-    for (var i = 0; i < cardTable.length; i++) {
-      cardTable[i].style.height = cardHeight;
+    for (var i = 0; i < slides.length; i++) {
+      slides[i].style.height = slideHeight;
     }
 
     for (var i = 0; i < usages.length; i++) {
@@ -45,23 +42,10 @@ module.exports = {
       pagination: '.swiper-pagination',
       paginationClickable: true,
       nextButton: '.swiper-button-next',
-      prevButton: '.swiper-button-prev'
+      prevButton: '.swiper-button-prev',
+      slidesPerView: 'auto'
     };
 
-    if (width < 674) {
-      options.slidesPerView = 1;
-      options.spaceBetween = 30;
-      options.centeredSlides = true;
-    } else if (width < 1025) {
-      options.slidesPerView = 2;
-      options.spaceBetween = 5;
-    } else if (width < 1700) {
-      options.slidesPerView = 4;
-      options.spaceBetween = 5;
-    } else if (width >= 1700) {
-      options.slidesPerView = 5;
-      options.spaceBetween = 20;
-    }
     var swiper = new Swiper('.swiper', options);
   }
 };

--- a/src/templates/cards.tag
+++ b/src/templates/cards.tag
@@ -1,46 +1,40 @@
 <offer-card>
-    <div class="card_table">
-        <div class="logo" style={parent.cssStyleRules(undefined, item.primary_color)} id={item.id}>
-            <img src={item.logo}></img>
-        </div>
-        <h1 style={parent.cssStyleRules(item.secondary_color)} class="name" id={item.id}>{item.name}</h1>
-        <raw class="usage" content="{item.description}"></raw>
-        <a class ="details" style={parent.cssStyleRules(item.secondary_color)} href={parent.formatDetailsUrl(item.repositoryId, item.id)}>More Details</a>
-        <a target="_blank" href="{item.paymentUrl}" style={parent.cssStyleRules('#fff', item.primary_color)} class="button" id={item.id}> Buy for {parent.formatMoney(item.price.value, item.price.unit)}</a>
-        <div class="footer-logo">
-            <p>Powered by </p> <img src="../src/templates/logos/opp-logo.png"></img>
-        </div>
+    <div class="logo" style={parent.cssStyleRules(undefined, item.primary_color)} id={item.id}>
+        <img src={item.logo}></img>
+    </div>
+    <h1 style={parent.cssStyleRules(item.secondary_color)} class="name" id={item.id}>{item.name}</h1>
+    <raw class="usage" content="{item.description}"></raw>
+    <a class ="details" style={parent.cssStyleRules(item.secondary_color)} href={parent.formatDetailsUrl(item.repositoryId, item.id)}>More Details</a>
+    <a target="_blank" href="{item.paymentUrl}" style={parent.cssStyleRules('#fff', item.primary_color)} class="button" id={item.id}> Buy for {parent.formatMoney(item.price.value, item.price.unit)}</a>
+    <div class="footer-logo">
+        <p>Powered by </p> <img src="../src/templates/logos/opp-logo.png"></img>
     </div>
 </offer-card>
 
 <organisation-card>
-    <div class="card_table">
-        <div class="logo" style={parent.cssStyleRules(undefined, item.primary_color)} id={item.id}>
-            <img src={item.logo}></img>
-        </div>
-        <h1 style={parent.cssStyleRules(item.secondary_color)} class="name" id={item.id}>{item.name}</h1>
-        <raw class="usage" content="{item.description}"></raw>
-        <a if={item.link} href={item.link} style={parent.cssStyleRules('#fff', item.primary_color)}  class="button" id={item.id}> Go to Site</a>
-        <div class="footer-logo">
-            <p>Powered by </p> <img src="../src/templates/logos/opp-logo.png"></img>
-        </div>
+    <div class="logo" style={parent.cssStyleRules(undefined, item.primary_color)} id={item.id}>
+        <img src={item.logo}></img>
+    </div>
+    <h1 style={parent.cssStyleRules(item.secondary_color)} class="name" id={item.id}>{item.name}</h1>
+    <raw class="usage" content="{item.description}"></raw>
+    <a if={item.link} href={item.link} style={parent.cssStyleRules('#fff', item.primary_color)}  class="button" id={item.id}> Go to Site</a>
+    <div class="footer-logo">
+        <p>Powered by </p> <img src="../src/templates/logos/opp-logo.png"></img>
     </div>
 </organisation-card>
 
 <cards>
-    <div class="all">
-        <div class="swiper-container swiper" id="container">
-            <div class="swiper-wrapper" id="wrapper">
-                <div each={item in this.items} class="swiper-slide">
-                    <offer-card if={parent.type=='offer'} item={item}/>
-                    <organisation-card if={parent.type=='licensor'} item={item}/>
-                    <organisation-card if={parent.type=='link'} item={item}/>
-                </div>
+    <div class="swiper-container swiper" id="container">
+        <div class="swiper-wrapper" id="wrapper">
+            <div each={item in this.items} class="swiper-slide">
+                <offer-card if={parent.type=='offer'} item={item}/>
+                <organisation-card if={parent.type=='licensor'} item={item}/>
+                <organisation-card if={parent.type=='link'} item={item}/>
             </div>
-            <div class="swiper-pagination swiper-pagination-white" id="pagination"></div>
-            <div class="swiper-button-next swiper-button-white"></div>
-            <div class="swiper-button-prev swiper-button-white"></div>
         </div>
+        <div class="swiper-pagination swiper-pagination-white" id="pagination"></div>
+        <div class="swiper-button-next swiper-button-white"></div>
+        <div class="swiper-button-prev swiper-button-white"></div>
     </div>
 
     <script>
@@ -64,73 +58,31 @@
     </script>
 
     <style>
-        .all{
-          border-top: solid 0.08em #FFF;
-          border-bottom: solid 0.08em #FFF;
-          width:100%;
-          height:470px;
-          margin: 0 auto;
-        }
-        /* Container class for swiper */
-        .swiper-container {
-            width: 100%;
-            height: 100%;
-            margin: 0 auto;
-        }
-        /* Container class for swiper slider */
-        .swiper-slide {
-            width: 100%;
-            /* Center slide text vertically */
-            display: -webkit-box;
-            display: -ms-flexbox;
-            display: -webkit-flex;
-            display: flex;
-            -webkit-box-pack: center;
-            -ms-flex-pack: center;
-            -webkit-justify-content: center;
-            justify-content: center;
-            -webkit-box-align: center;
-            -ms-flex-align: center;
-            -webkit-align-items: center;
-            align-items: center;
-        }
+    #container {
+      border-top: solid 0.08em #FFF;
+      border-bottom: solid 0.08em #FFF;
+      width:100%;
+      height:470px;
+      margin: 0 auto;
+    }
 
-        /* Media queries for different screen sizes to stop showing the Swiper classes in case someone **really** wants to resize the window continuosly */
-        @media screen and (max-width: 320px)
-        {
+    #container .swiper-slide {
+      width:250px;
+      height:400px;
+      margin: 20px;
+      background: #fff;
+      -webkit-box-shadow: 2px 2px 9px rgba(0,0,0,0.3);
+         -moz-box-shadow: 2px 2px 9px rgba(0,0,0,0.3);
+              box-shadow: 2px 2px 9px rgba(0,0,0,0.3);
+	}
 
-            .swiper-button-prev {
-                margin-left: -6px;
-            }
-            .swiper-button-next {
-                margin-right: -6px;
-            }
-        }
+	#container .swiper-button-prev,
+	#container .swiper-button-next {
+	    height: 20px;
+	    top: 98%;
+	}
 
-        /* Class for the card */
-        .card_table {
-          position:relative;
-          width:250px;
-          height:400px;
-          background: #fff;
-
-          -webkit-box-shadow: 2px 2px 9px rgba(0,0,0,0.3);
-             -moz-box-shadow: 2px 2px 9px rgba(0,0,0,0.3);
-                  box-shadow: 2px 2px 9px rgba(0,0,0,0.3);
-        }
-        /* Centered version for Swiper */
-        .card_table#mobile{
-            margin:0 auto;
-
-        }
-        /* Responsive version for Desktop */
-        .card_table#desk {
-          float:left;
-          margin-top:50px;
-          margin-left:50px;
-          margin-bottom:50px;
-        }
-        .button_span {
+	.button_span {
            float: right;
            position: relative;
            left: -50%; /* or right 50% */
@@ -144,7 +96,7 @@
           font-family: 'Signika', sans-serif;
         }
 
-        .card_table h1 {
+        .swiper-slide h1 {
           margin: 0;
           padding:0 0 10px 0;
           height: 10%;

--- a/src/templates/error.tag
+++ b/src/templates/error.tag
@@ -1,5 +1,5 @@
 <failure>
-  <div class="all">
+  <div id="container">
       <div class="error_card">
         <h1>Not Found</h1>
         <div class="body">
@@ -17,7 +17,7 @@
 </failure>
 
 <error>
-  <div class="all">
+  <div id="container">
       <div class="error_card">
         <h1> Error </h1>
         <div class="body">


### PR DESCRIPTION
If we try to manually determine the number of slides to show, things start to go very weird when the parent is a modal (as it can't accurately determine the size of the parent element).

By letting swiper automatically determine how many slides to display, we do lose some features like centered slides on mobile view, but overall the behaviour seems more consistent, and it's more extensible for use with other components.

<img width="1440" alt="screen shot 2016-07-04 at 13 44 39" src="https://cloud.githubusercontent.com/assets/12034521/16560838/996a702e-41ed-11e6-95fb-effe201e64d9.png">
<img width="401" alt="screen shot 2016-07-04 at 13 45 13" src="https://cloud.githubusercontent.com/assets/12034521/16560841/9ba8e730-41ed-11e6-8139-3664223f1ac9.png">
